### PR TITLE
Support for multi-value parameters (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 poetry.lock
 starlette_lambda.egg-info
+/.idea/
+__pycache__

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-starlette==0.11.4
-uvicorn==0.3.32
+.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [
 
 setup(
     name="starlette-lambda",
-    version="0.1.0",
+    version="0.1.1",
     author="Alokin",
     author_email="hello@alokin.in",
     description="",

--- a/tests/test_multi_value.py
+++ b/tests/test_multi_value.py
@@ -1,0 +1,25 @@
+from starlette.applications import Starlette
+
+from starlette_lambda.aws import LambdaFunction
+
+
+def test_multi_value():
+    query_string = LambdaFunction(asgi=Starlette()).get_query_string(event={
+        'queryStringParameters': {'make': 'TOYOTA', 'zip_code': '65301'},
+        'multiValueQueryStringParameters': {
+            'zip_code': ['02368', '65301']
+        }
+    })
+
+    assert query_string == 'make=TOYOTA&zip_code=02368&zip_code=65301'
+
+
+def test_pseudo_multi_value():
+    query_string = LambdaFunction(asgi=Starlette()).get_query_string(event={
+        'queryStringParameters': {'make': 'TOYOTA', 'zip_code': '65301'},
+        'multiValueQueryStringParameters': {
+            'zip_code': ['02368']
+        }
+    })
+
+    assert query_string == 'make=TOYOTA&zip_code=02368'

--- a/tests/test_starlette_lambda.py
+++ b/tests/test_starlette_lambda.py
@@ -34,7 +34,6 @@ class LambdaContext(object):
             self.client_context.client = None
         self.identity = None
 
-
     def get_remaining_time_in_millis(self):
         return None
 


### PR DESCRIPTION
Thanks @anatoly-scherbakov for this contribution

* Reuse setup.py in requirements.txt and ignore PyCharm configuration directory

* Factored out get_connection_scope() and added a failing unit test to demonstrate it does not handle multi-value GET parameters properly

* Unit tests now pass

* Unit tests to be more granular

* bump version